### PR TITLE
fix: correct react type dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,20 +41,22 @@
     "typecheck": "tsc -b --pretty --force"
   },
   "dependencies": {
-    "@types/react": "^19.2.17",
     "@types/supercluster": "^7.1.3",
     "dequal": "^2.0.3",
     "esm-env": "^1.2.2",
     "supercluster": "^8.0.1"
   },
   "peerDependencies": {
+    "@types/react": ">=16.8.0",
     "mapbox-gl": "*",
     "maplibre-gl": "*",
     "react": ">=16.8.0",
-    "react-dom": "*",
     "react-map-gl": "^8"
   },
   "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    },
     "mapbox-gl": {
       "optional": true
     },
@@ -68,6 +70,7 @@
     "@tsconfig/strictest": "^2.0.8",
     "@tsconfig/vite-react": "^8.1.1",
     "@types/node": "^24.13.3",
+    "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
     "@vitest/coverage-v8": "^4.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@types/react':
-        specifier: ^19.2.17
-        version: 19.2.17
       '@types/supercluster':
         specifier: ^7.1.3
         version: 7.1.3
@@ -39,6 +36,9 @@ importers:
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)


### PR DESCRIPTION
## Summary

Fixes how React type dependencies are declared for a published library.

### `@types/react`
Moved from `dependencies` to an **optional `peerDependency`** (`>=16.8.0`, paired with `react`), and added to `devDependencies` for local build/tests.

Previously it sat in `dependencies`, which forced `@types/react@19` onto every consumer — including JS-only projects (no types needed) and projects on an older React major (duplicate `@types/react` majors in the tree → JSX namespace conflicts). As an optional peer it now follows the consumer's own React version. The library's public `.d.ts` does reference React types (`RefObject`), so the types are genuinely needed — but as a peer.

### `react-dom`
Dropped from `peerDependencies`. The library does not import `react-dom` at runtime or in its public types; only the test suite uses `react-dom/client`, which is already covered by `devDependencies`.

`@types/supercluster` intentionally stays in `dependencies` — `supercluster` is a runtime dependency and ships no bundled types, so the library must carry them.

## Verification
- `pnpm check` (lint + typecheck + test) — green, 34 tests, 100% coverage
- `pnpm build` — green