### PR TITLE
feat!: v4 — useSyncExternalStore, boundsPadding, plain point features

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,21 +36,15 @@ There is no root entrypoint in v3+ because `react-map-gl` v8 no longer has a def
 ```tsx
 import { type ReactElement, useMemo, useRef } from 'react'
 import Map, { type MapRef, Marker } from 'react-map-gl/mapbox'
-import {
-  isCluster,
-  type PointClusterProperties,
-  type PointFeature,
-  type PointFeatureProperties,
-  useSupercluster,
-} from 'react-map-gl-supercluster/mapbox'
+import { isCluster, type PointFeature, useSupercluster } from 'react-map-gl-supercluster/mapbox'
 
 type Item = {
   id: string
   longitude: number
   latitude: number
 }
-type ItemPointFeatureProperties = PointFeatureProperties<{ item: Item }>
-type ItemPointClusterProperties = PointClusterProperties<{ items: Item[] }>
+type ItemProperties = { item: Item }
+type ItemClusterProperties = { items: Item[] }
 
 function MyAwesomeMap({ items }: { items: Item[] }): ReactElement {
   const mapRef = useRef<MapRef | null>(null)
@@ -91,14 +85,14 @@ function MyAwesomeMap({ items }: { items: Item[] }): ReactElement {
   )
 }
 
-function createPoints(items: Item[]): Array<PointFeature<ItemPointFeatureProperties>> {
+function createPoints(items: Item[]): Array<PointFeature<ItemProperties>> {
   return items.map(createPoint)
 }
 
-function createPoint(item: Item): PointFeature<ItemPointFeatureProperties> {
+function createPoint(item: Item): PointFeature<ItemProperties> {
   return {
     type: 'Feature',
-    properties: { cluster: false, item },
+    properties: { item },
     geometry: {
       type: 'Point',
       coordinates: [item.longitude, item.latitude],
@@ -106,11 +100,11 @@ function createPoint(item: Item): PointFeature<ItemPointFeatureProperties> {
   }
 }
 
-function mapFeature(props: ItemPointFeatureProperties): ItemPointClusterProperties {
+function mapFeature(props: ItemProperties): ItemClusterProperties {
   return { items: [props.item] }
 }
 
-function reduceCluster(memo: ItemPointClusterProperties, props: ItemPointClusterProperties): void {
+function reduceCluster(memo: ItemClusterProperties, props: ItemClusterProperties): void {
   memo.items = memo.items.concat(props.items)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ There is no root entrypoint in v3+ because `react-map-gl` v8 no longer has a def
 ## Example usage
 
 ```tsx
-import { type ReactElement, useMemo, useRef } from 'react'
+import { type ReactElement, useMemo, useState } from 'react'
 import Map, { type MapRef, Marker } from 'react-map-gl/mapbox'
 import { isCluster, type PointFeature, useSupercluster } from 'react-map-gl-supercluster/mapbox'
 
@@ -47,26 +47,26 @@ type ItemProperties = { item: Item }
 type ItemClusterProperties = { items: Item[] }
 
 function MyAwesomeMap({ items }: { items: Item[] }): ReactElement {
-  const mapRef = useRef<MapRef | null>(null)
+  const [map, setMap] = useState<MapRef | null>(null)
 
   const points = useMemo(() => createPoints(items), [items])
 
   const { supercluster, clusters } = useSupercluster(points, {
-    mapRef,
+    mapRef: map,
     map: mapFeature,
     reduce: reduceCluster,
   })
 
   const expandCluster = (clusterId: number, coordinates: { longitude: number; latitude: number }) => {
     const zoom = supercluster.getClusterExpansionZoom(clusterId)
-    mapRef.current?.easeTo({
+    map?.easeTo({
       center: [coordinates.longitude, coordinates.latitude],
       zoom,
     })
   }
 
   return (
-    <Map ref={mapRef}>
+    <Map ref={setMap}>
       {clusters.map((cluster) => {
         const [longitude, latitude] = cluster.geometry.coordinates
 
@@ -189,7 +189,7 @@ Object which contains 2 fields:
 
 | Option     | Default  | Description                                                                                                                                                                          |
 | ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| mapRef     | Optional | `MapRef` instance or React ref. Optional when the hook is rendered inside `Map`.                                                                                                      |
+| mapRef     | Optional | `MapRef` instance. Optional when the hook is rendered inside `Map`.                                                                                                                    |
 | boundsPadding | 0     | Extra viewport fraction (per side) included when querying clusters. Markers near the edges don't pop in and out, and small pans skip recomputation. Larger values render more off-screen markers. |
 | minZoom    | 0        | Minimum zoom level at which clusters are generated.                                                                                                                                  |
 | maxZoom    | 16       | Maximum zoom level at which clusters are generated.                                                                                                                                  |

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Object which contains 2 fields:
 | Option     | Default  | Description                                                                                                                                                                          |
 | ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | mapRef     | Optional | `MapRef` instance or React ref. Optional when the hook is rendered inside `Map`.                                                                                                      |
+| boundsPadding | 0     | Extra viewport fraction (per side) included when querying clusters. Markers near the edges don't pop in and out, and small pans skip recomputation. Larger values render more off-screen markers. |
 | minZoom    | 0        | Minimum zoom level at which clusters are generated.                                                                                                                                  |
 | maxZoom    | 16       | Maximum zoom level at which clusters are generated.                                                                                                                                  |
 | minPoints  | 2        | Minimum number of points to form a cluster.                                                                                                                                          |

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Object which contains 2 fields:
 | Option     | Default  | Description                                                                                                                                                                          |
 | ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | mapRef     | Optional | `MapRef` instance. Optional when the hook is rendered inside `Map`.                                                                                                                    |
-| boundsPadding | 0     | Extra viewport fraction (per side) included when querying clusters. Markers near the edges don't pop in and out, and small pans skip recomputation. Larger values render more off-screen markers. |
+| boundsPadding | 0     | Extra viewport fraction (per side) included when querying clusters. Markers near the edges don't pop in and out, and pans at the same zoom inside the padded area skip recomputation. Larger values render more off-screen markers. |
 | minZoom    | 0        | Minimum zoom level at which clusters are generated.                                                                                                                                  |
 | maxZoom    | 16       | Maximum zoom level at which clusters are generated.                                                                                                                                  |
 | minPoints  | 2        | Minimum number of points to form a cluster.                                                                                                                                          |
@@ -208,6 +208,10 @@ Object which contains 2 fields:
 ### Why does it cause component re-rendering or why do I get infinite component update loop?
 
 Please be careful with `points` and `map`/`reduce` functions. They always should be memoized.
+
+### Why does TypeScript reject my properties type?
+
+Properties types must satisfy `Record<string, unknown>`. Type aliases get an implicit index signature, `interface` declarations don't — declare properties types with `type`, not `interface`. Also note that the `cluster` key is reserved for generated clusters and must not appear in point properties.
 
 ### Does it support WebWorker?
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -59,6 +59,7 @@ export default function App() {
 
   const { supercluster, clusters } = useSupercluster<PlaceFeatureProperties, PlaceClusterProperties>(points, {
     mapRef: map,
+    boundsPadding: 0.2,
     map: mapFeature,
     reduce: reduceCluster,
   })

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,13 +1,7 @@
 import { useCallback, useMemo, useState } from 'react'
 import MapComponent, { type MapRef, Marker, NavigationControl, Popup } from 'react-map-gl/maplibre'
 import 'maplibre-gl/dist/maplibre-gl.css'
-import {
-  isCluster,
-  type PointClusterProperties,
-  type PointFeature,
-  type PointFeatureProperties,
-  useSupercluster,
-} from 'react-map-gl-supercluster/maplibre'
+import { isCluster, type PointFeature, useSupercluster } from 'react-map-gl-supercluster/maplibre'
 import { type Place, places } from './data.js'
 
 type PlaceFeatureProperties = {
@@ -25,11 +19,11 @@ export default function App() {
   const [map, setMap] = useState<MapRef | null>(null)
   const [selectedPlace, setSelectedPlace] = useState<Place | null>(null)
 
-  const points = useMemo<Array<PointFeature<PointFeatureProperties<PlaceFeatureProperties>>>>(
+  const points = useMemo<Array<PointFeature<PlaceFeatureProperties>>>(
     () =>
       places.map((place) => ({
         type: 'Feature',
-        properties: { cluster: false, place },
+        properties: { place },
         geometry: {
           type: 'Point',
           coordinates: [place.longitude, place.latitude],
@@ -39,23 +33,17 @@ export default function App() {
   )
 
   const mapFeature = useCallback(
-    (properties: PointFeatureProperties<PlaceFeatureProperties>): PointClusterProperties<PlaceClusterProperties> => ({
+    (properties: PlaceFeatureProperties): PlaceClusterProperties => ({
       places: [properties.place],
       totalAttendees: properties.place.attendees,
     }),
     [],
   )
 
-  const reduceCluster = useCallback(
-    (
-      memo: PointClusterProperties<PlaceClusterProperties>,
-      properties: PointClusterProperties<PlaceClusterProperties>,
-    ): void => {
-      memo.places = memo.places.concat(properties.places)
-      memo.totalAttendees += properties.totalAttendees
-    },
-    [],
-  )
+  const reduceCluster = useCallback((memo: PlaceClusterProperties, properties: PlaceClusterProperties): void => {
+    memo.places = memo.places.concat(properties.places)
+    memo.totalAttendees += properties.totalAttendees
+  }, [])
 
   const { supercluster, clusters } = useSupercluster<PlaceFeatureProperties, PlaceClusterProperties>(points, {
     mapRef: map,

--- a/package.json
+++ b/package.json
@@ -47,10 +47,10 @@
     "supercluster": "^8.0.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0",
+    "@types/react": ">=18.0.0",
     "mapbox-gl": "*",
     "maplibre-gl": "*",
-    "react": ">=16.8.0",
+    "react": ">=18.0.0",
     "react-map-gl": "^8"
   },
   "peerDependenciesMeta": {

--- a/src/exports-mapbox-legacy.ts
+++ b/src/exports-mapbox-legacy.ts
@@ -6,7 +6,6 @@ export { isCluster } from './is-cluster.js'
 export type {
   Cluster,
   ClusterFeature,
-  PointClusterProperties,
   PointFeature,
   PointFeatureProperties,
   SuperclusterInstance,

--- a/src/exports-mapbox-legacy.ts
+++ b/src/exports-mapbox-legacy.ts
@@ -6,6 +6,7 @@ export { isCluster } from './is-cluster.js'
 export type {
   Cluster,
   ClusterFeature,
+  GeoJsonProperties,
   PointFeature,
   PointFeatureProperties,
   SuperclusterInstance,

--- a/src/exports-mapbox.ts
+++ b/src/exports-mapbox.ts
@@ -6,7 +6,6 @@ export { isCluster } from './is-cluster.js'
 export type {
   Cluster,
   ClusterFeature,
-  PointClusterProperties,
   PointFeature,
   PointFeatureProperties,
   SuperclusterInstance,

--- a/src/exports-mapbox.ts
+++ b/src/exports-mapbox.ts
@@ -6,6 +6,7 @@ export { isCluster } from './is-cluster.js'
 export type {
   Cluster,
   ClusterFeature,
+  GeoJsonProperties,
   PointFeature,
   PointFeatureProperties,
   SuperclusterInstance,

--- a/src/exports-maplibre.ts
+++ b/src/exports-maplibre.ts
@@ -6,7 +6,6 @@ export { isCluster } from './is-cluster.js'
 export type {
   Cluster,
   ClusterFeature,
-  PointClusterProperties,
   PointFeature,
   PointFeatureProperties,
   SuperclusterInstance,

--- a/src/exports-maplibre.ts
+++ b/src/exports-maplibre.ts
@@ -6,6 +6,7 @@ export { isCluster } from './is-cluster.js'
 export type {
   Cluster,
   ClusterFeature,
+  GeoJsonProperties,
   PointFeature,
   PointFeatureProperties,
   SuperclusterInstance,

--- a/src/is-cluster.test.ts
+++ b/src/is-cluster.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { isCluster } from './is-cluster.js'
 import { pointFeature, type TestClusterProperties, type TestProperties } from './test-helpers.js'
-import type { Cluster, ClusterFeature, PointClusterProperties } from './types.js'
+import type { Cluster, ClusterFeature } from './types.js'
 
 type TestCluster = Cluster<TestProperties, TestClusterProperties>
 
@@ -19,7 +19,7 @@ describe('isCluster', () => {
   })
 })
 
-function clusterFeature(id: number, sum: number): ClusterFeature<PointClusterProperties<TestClusterProperties>> {
+function clusterFeature(id: number, sum: number): ClusterFeature<TestClusterProperties> {
   return {
     geometry: { coordinates: [0, 0], type: 'Point' },
     id,

--- a/src/is-cluster.ts
+++ b/src/is-cluster.ts
@@ -1,4 +1,4 @@
-import type { Cluster, ClusterFeature, GeoJsonProperties, PointClusterProperties } from './types.js'
+import type { Cluster, ClusterFeature, GeoJsonProperties, PointFeatureProperties } from './types.js'
 
 /**
  * Narrows a feature returned from `useSupercluster` to a generated cluster.
@@ -8,8 +8,9 @@ import type { Cluster, ClusterFeature, GeoJsonProperties, PointClusterProperties
  * clusters.map((feature) => (isCluster(feature) ? renderCluster(feature) : renderPoint(feature)))
  * ```
  */
-export function isCluster<TFeatureProperties extends GeoJsonProperties, TClusterProperties extends GeoJsonProperties>(
-  feature: Cluster<TFeatureProperties, TClusterProperties>,
-): feature is ClusterFeature<PointClusterProperties<TClusterProperties>> {
+export function isCluster<
+  TFeatureProperties extends PointFeatureProperties,
+  TClusterProperties extends GeoJsonProperties,
+>(feature: Cluster<TFeatureProperties, TClusterProperties>): feature is ClusterFeature<TClusterProperties> {
   return feature.properties.cluster === true
 }

--- a/src/map-state.test.ts
+++ b/src/map-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getMapState, isMapStateEqual } from './map-state.js'
+import { containsBounds, expandBounds, getMapState, isMapStateEqual } from './map-state.js'
 import { TestMap } from './test-helpers.js'
 
 describe('isMapStateEqual', () => {
@@ -23,6 +23,33 @@ describe('isMapStateEqual', () => {
     expect(isMapStateEqual(null, null)).toBe(true)
     expect(isMapStateEqual(null, { bounds: [-10, -20, 10, 20], zoom: 4 })).toBe(false)
     expect(isMapStateEqual({ bounds: [-10, -20, 10, 20], zoom: 4 }, null)).toBe(false)
+  })
+})
+
+describe('expandBounds', () => {
+  it('expands each side by the given fraction of the viewport size', () => {
+    expect(expandBounds([0, 0, 10, 20], 0.5)).toEqual([-5, -10, 15, 30])
+  })
+
+  it('does not clamp to world limits (supercluster normalizes the bbox itself)', () => {
+    expect(expandBounds([170, 80, 180, 85], 1)).toEqual([160, 75, 190, 90])
+  })
+})
+
+describe('containsBounds', () => {
+  it('accepts inner bounds fully inside outer', () => {
+    expect(containsBounds([-10, -10, 10, 10], [-5, -5, 5, 5])).toBe(true)
+  })
+
+  it('accepts equal bounds', () => {
+    expect(containsBounds([-10, -10, 10, 10], [-10, -10, 10, 10])).toBe(true)
+  })
+
+  it('rejects bounds sticking out on any side', () => {
+    expect(containsBounds([-10, -10, 10, 10], [-11, -5, 5, 5])).toBe(false)
+    expect(containsBounds([-10, -10, 10, 10], [-5, -11, 5, 5])).toBe(false)
+    expect(containsBounds([-10, -10, 10, 10], [-5, -5, 11, 5])).toBe(false)
+    expect(containsBounds([-10, -10, 10, 10], [-5, -5, 5, 11])).toBe(false)
   })
 })
 

--- a/src/map-state.ts
+++ b/src/map-state.ts
@@ -1,6 +1,6 @@
 import type { MapLike } from './types.js'
 
-type MapBounds = [number, number, number, number]
+export type MapBounds = [number, number, number, number]
 
 /** Snapshot of the map viewport used to query clusters. */
 export type MapState = {
@@ -25,4 +25,16 @@ export function isMapStateEqual(a: MapState | null, b: MapState | null): boolean
 
 function isBoundsEqual(a: MapBounds, b: MapBounds): boolean {
   return a === b || (a[0] === b[0] && a[1] === b[1] && a[2] === b[2] && a[3] === b[3])
+}
+
+// No clamping to world limits: supercluster normalizes an out-of-range bbox itself
+export function expandBounds(bounds: MapBounds, padding: number): MapBounds {
+  const [west, south, east, north] = bounds
+  const paddingLng = (east - west) * padding
+  const paddingLat = (north - south) * padding
+  return [west - paddingLng, south - paddingLat, east + paddingLng, north + paddingLat]
+}
+
+export function containsBounds(outer: MapBounds, inner: MapBounds): boolean {
+  return outer[0] <= inner[0] && outer[1] <= inner[1] && outer[2] >= inner[2] && outer[3] >= inner[3]
 }

--- a/src/perf.bench.ts
+++ b/src/perf.bench.ts
@@ -4,7 +4,7 @@ import { isClustersShallowEqual } from './cluster-equality.js'
 import { getMapState, isMapStateEqual } from './map-state.js'
 import type { MapLike, PointFeature } from './types.js'
 
-type Properties = { cluster: false; value: number }
+type Properties = { value: number }
 
 function makePoints(count: number): Array<PointFeature<Properties>> {
   const points: Array<PointFeature<Properties>> = []
@@ -12,7 +12,7 @@ function makePoints(count: number): Array<PointFeature<Properties>> {
     points.push({
       geometry: { coordinates: [Math.random() * 360 - 180, Math.random() * 170 - 85], type: 'Point' },
       id: i,
-      properties: { cluster: false, value: i },
+      properties: { value: i },
       type: 'Feature',
     })
   }

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -4,14 +4,14 @@ import type { MapLike, PointFeature } from './types.js'
 
 ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
-export type TestProperties = { cluster: false; value: number }
+export type TestProperties = { value: number }
 export type TestClusterProperties = { sum: number }
 
 export function pointFeature(id: number, coordinates: number[], value = id): PointFeature<TestProperties> {
   return {
     geometry: { coordinates, type: 'Point' },
     id,
-    properties: { cluster: false, value },
+    properties: { value },
     type: 'Feature',
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,7 +73,7 @@ export type MapFeatureToCluster<
  */
 export type ReduceCluster<TClusterProperties extends GeoJsonProperties> = (
   memo: TClusterProperties,
-  feature: TClusterProperties,
+  feature: Readonly<TClusterProperties>,
 ) => void
 
 /**
@@ -95,15 +95,15 @@ export type SuperclusterOptions<
   TFeatureProperties extends GeoJsonProperties,
   TClusterProperties extends GeoJsonProperties,
 > = {
-  minZoom?: number
-  maxZoom?: number
-  radius?: number
-  minPoints?: number
-  extent?: number
-  nodeSize?: number
-  generateId?: boolean
-  map?: MapFeatureToCluster<TFeatureProperties, TClusterProperties>
-  reduce?: ReduceCluster<TClusterProperties>
+  minZoom?: number | undefined
+  maxZoom?: number | undefined
+  radius?: number | undefined
+  minPoints?: number | undefined
+  extent?: number | undefined
+  nodeSize?: number | undefined
+  generateId?: boolean | undefined
+  map?: MapFeatureToCluster<TFeatureProperties, TClusterProperties> | undefined
+  reduce?: ReduceCluster<TClusterProperties> | undefined
 }
 
 type LngLatBounds = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,27 +9,20 @@ export type GeoJsonProperties = Record<string, unknown>
 /**
  * Point properties accepted by `useSupercluster`.
  *
- * @example
- * ```ts
- * type CityPoint = PointFeatureProperties<{ name: string; population: number }>
- * ```
- */
-export type PointFeatureProperties<TProperties extends GeoJsonProperties> = { cluster: false } & TProperties
-
-/**
- * User-defined aggregate properties for generated cluster features.
+ * The `cluster` key is reserved: generated clusters use it as a discriminator,
+ * so input points must not define it. Use `isCluster` to tell features apart.
  *
  * @example
  * ```ts
- * type CityCluster = PointClusterProperties<{ population: number }>
+ * type CityPoint = { name: string; population: number } // satisfies PointFeatureProperties
  * ```
  */
-export type PointClusterProperties<TProperties extends GeoJsonProperties> = TProperties
+export type PointFeatureProperties = GeoJsonProperties & { cluster?: never }
 
 /** A feature returned from `useSupercluster`: either an original point or a generated cluster. */
 export type Cluster<TFeatureProperties extends GeoJsonProperties, TClusterProperties extends GeoJsonProperties> =
-  | PointFeature<PointFeatureProperties<TFeatureProperties>>
-  | ClusterFeature<PointClusterProperties<TClusterProperties>>
+  | PointFeature<TFeatureProperties>
+  | ClusterFeature<TClusterProperties>
 
 /**
  * Loaded `supercluster` instance returned by the hook.
@@ -44,7 +37,7 @@ export type Cluster<TFeatureProperties extends GeoJsonProperties, TClusterProper
 export type SuperclusterInstance<
   TFeatureProperties extends GeoJsonProperties,
   TClusterProperties extends GeoJsonProperties,
-> = Omit<Supercluster<PointFeatureProperties<TFeatureProperties>, PointClusterProperties<TClusterProperties>>, 'load'>
+> = Omit<Supercluster<TFeatureProperties, TClusterProperties>, 'load'>
 
 /**
  * Maps point properties to the aggregate properties used by clusters.
@@ -64,7 +57,7 @@ export type SuperclusterInstance<
 export type MapFeatureToCluster<
   TFeatureProperties extends GeoJsonProperties,
   TClusterProperties extends GeoJsonProperties,
-> = (feature: PointFeatureProperties<TFeatureProperties>) => PointClusterProperties<TClusterProperties>
+> = (feature: TFeatureProperties) => TClusterProperties
 
 /**
  * Merges aggregate properties while building clusters.
@@ -79,8 +72,8 @@ export type MapFeatureToCluster<
  * ```
  */
 export type ReduceCluster<TClusterProperties extends GeoJsonProperties> = (
-  memo: PointClusterProperties<TClusterProperties>,
-  feature: PointClusterProperties<TClusterProperties>,
+  memo: TClusterProperties,
+  feature: TClusterProperties,
 ) => void
 
 /**

--- a/src/use-clusters.test.ts
+++ b/src/use-clusters.test.ts
@@ -1,13 +1,17 @@
 import React, { act } from 'react'
 import { renderToString } from 'react-dom/server'
 import Supercluster from 'supercluster'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { pointFeature, renderHook, type TestClusterProperties, TestMap, type TestProperties } from './test-helpers.js'
 import type { PointFeature, SuperclusterInstance } from './types.js'
 import { useClusters } from './use-clusters.js'
 
 type Index = SuperclusterInstance<TestProperties, TestClusterProperties>
-type Props = { map: TestMap | null; index: Index }
+type Props = { map: TestMap | null; index: Index; boundsPadding?: number }
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 const worldMap = () =>
   new TestMap([
@@ -162,6 +166,132 @@ describe('useClusters', () => {
     expect(view.result.clusters).toHaveLength(1)
   })
 
+  describe('boundsPadding', () => {
+    it('includes clusters slightly outside the viewport', async () => {
+      const map = new TestMap([
+        [-10, -10],
+        [10, 10],
+      ])
+      const index = createIndex([pointFeature(1, [12, 12])])
+      const view = await renderClusters({ boundsPadding: 0.5, index, map })
+
+      expect(view.result.clusters).toHaveLength(1)
+    })
+
+    it('does not include clusters outside the viewport without padding', async () => {
+      const map = new TestMap([
+        [-10, -10],
+        [10, 10],
+      ])
+      const index = createIndex([pointFeature(1, [12, 12])])
+      const view = await renderClusters({ index, map })
+
+      expect(view.result.clusters).toEqual([])
+    })
+
+    it('skips recomputation while the viewport stays inside the padded area', async () => {
+      const map = new TestMap([
+        [-10, -10],
+        [10, 10],
+      ])
+      const index = createIndex([pointFeature(1, [0, 0])])
+      const getClusters = vi.spyOn(index, 'getClusters')
+      const view = await renderClusters({ boundsPadding: 0.5, index, map })
+      const callsAfterMount = getClusters.mock.calls.length
+      const previousResult = view.result
+
+      await act(async () => {
+        map.setView(
+          [
+            [-12, -12],
+            [8, 8],
+          ],
+          0.2,
+        )
+        map.emit('move')
+      })
+
+      expect(view.result).toBe(previousResult)
+      expect(getClusters.mock.calls.length).toBe(callsAfterMount)
+    })
+
+    it('recomputes when the viewport leaves the padded area', async () => {
+      const map = new TestMap([
+        [-10, -10],
+        [10, 10],
+      ])
+      const index = createIndex([pointFeature(1, [40, 40])])
+      const getClusters = vi.spyOn(index, 'getClusters')
+      const view = await renderClusters({ boundsPadding: 0.5, index, map })
+      expect(view.result.clusters).toEqual([])
+      const callsAfterMount = getClusters.mock.calls.length
+
+      await act(async () => {
+        map.setView(
+          [
+            [25, 25],
+            [45, 45],
+          ],
+          0,
+        )
+        map.emit('move')
+      })
+
+      expect(getClusters.mock.calls.length).toBeGreaterThan(callsAfterMount)
+      expect(view.result.clusters).toHaveLength(1)
+    })
+
+    it('recomputes when the rounded zoom changes inside the padded area', async () => {
+      const map = new TestMap([
+        [-10, -10],
+        [10, 10],
+      ])
+      const index = createIndex([pointFeature(1, [0, 0]), pointFeature(2, [0.01, 0.01])])
+      const getClusters = vi.spyOn(index, 'getClusters')
+      const view = await renderClusters({ boundsPadding: 0.5, index, map })
+      const callsAfterMount = getClusters.mock.calls.length
+
+      await act(async () => {
+        map.setView(
+          [
+            [-9, -9],
+            [9, 9],
+          ],
+          0.8,
+        )
+        map.emit('move')
+      })
+
+      expect(getClusters.mock.calls.length).toBeGreaterThan(callsAfterMount)
+      expect(view.result.clusters).toHaveLength(1)
+    })
+
+    it('always requeries without padding, even when the viewport shrinks', async () => {
+      const map = new TestMap([
+        [-10, -10],
+        [10, 10],
+      ])
+      const index = createIndex([pointFeature(1, [0, 0])])
+      const getClusters = vi.spyOn(index, 'getClusters')
+      const view = await renderClusters({ index, map })
+      const callsAfterMount = getClusters.mock.calls.length
+
+      await act(async () => {
+        map.setView(
+          [
+            [-5, -5],
+            [5, 5],
+          ],
+          0.2,
+        )
+        map.emit('move')
+      })
+
+      expect(view.result.clusters).toHaveLength(1)
+      expect(getClusters.mock.calls.length).toBeGreaterThan(callsAfterMount)
+    })
+  })
+
   it('renders empty clusters on the server even when a map is provided', () => {
     const index = createIndex([pointFeature(1, [0, 0]), pointFeature(2, [0.01, 0.01])])
     const rendered: { result: ReturnType<typeof useClusters<TestProperties, TestClusterProperties>> | null } = {
@@ -181,7 +311,7 @@ describe('useClusters', () => {
 })
 
 function renderClusters(props: Props) {
-  return renderHook(({ map, index }: Props) => useClusters(map, index), props)
+  return renderHook(({ map, index, boundsPadding }: Props) => useClusters(map, index, boundsPadding), props)
 }
 
 function createIndex(points: Array<PointFeature<TestProperties>>): Index {

--- a/src/use-clusters.test.ts
+++ b/src/use-clusters.test.ts
@@ -142,7 +142,7 @@ describe('useClusters', () => {
 
     expect(view.result.supercluster).toBe(nextIndex)
     expect(view.result.clusters).toHaveLength(1)
-    expect(view.result.clusters[0]?.properties).toMatchObject({ cluster: false })
+    expect(view.result.clusters[0]?.properties).toEqual({ value: 3 })
     expect(map.listenerCount('move')).toBe(1)
   })
 
@@ -299,7 +299,7 @@ describe('useClusters', () => {
     }
 
     function ServerComponent(): null {
-      rendered.result = useClusters(worldMap(), index)
+      rendered.result = useClusters<TestProperties, TestClusterProperties>(worldMap(), index)
       return null
     }
 

--- a/src/use-clusters.test.ts
+++ b/src/use-clusters.test.ts
@@ -1,4 +1,5 @@
-import { act } from 'react'
+import React, { act } from 'react'
+import { renderToString } from 'react-dom/server'
 import Supercluster from 'supercluster'
 import { describe, expect, it } from 'vitest'
 import { pointFeature, renderHook, type TestClusterProperties, TestMap, type TestProperties } from './test-helpers.js'
@@ -159,6 +160,23 @@ describe('useClusters', () => {
     await view.rerender({ map: worldMap(), index })
 
     expect(view.result.clusters).toHaveLength(1)
+  })
+
+  it('renders empty clusters on the server even when a map is provided', () => {
+    const index = createIndex([pointFeature(1, [0, 0]), pointFeature(2, [0.01, 0.01])])
+    const rendered: { result: ReturnType<typeof useClusters<TestProperties, TestClusterProperties>> | null } = {
+      result: null,
+    }
+
+    function ServerComponent(): null {
+      rendered.result = useClusters(worldMap(), index)
+      return null
+    }
+
+    renderToString(React.createElement(ServerComponent))
+
+    expect(rendered.result?.clusters).toEqual([])
+    expect(rendered.result?.supercluster).toBe(index)
   })
 })
 

--- a/src/use-clusters.test.ts
+++ b/src/use-clusters.test.ts
@@ -166,6 +166,38 @@ describe('useClusters', () => {
     expect(view.result.clusters).toHaveLength(1)
   })
 
+  it('clears clusters and unsubscribes when the map goes away', async () => {
+    const map = worldMap()
+    const index = createIndex([pointFeature(1, [0, 0]), pointFeature(2, [0.01, 0.01])])
+    const view = await renderClusters({ map, index })
+    expect(view.result.clusters).toHaveLength(1)
+
+    await view.rerender({ map: null, index })
+
+    expect(view.result.clusters).toEqual([])
+    expect(map.listenerCount('move')).toBe(0)
+  })
+
+  it('moves the subscription to a replacement map', async () => {
+    const firstMap = new TestMap([
+      [-10, -10],
+      [10, 10],
+    ])
+    const nextMap = new TestMap([
+      [100, 50],
+      [120, 70],
+    ])
+    const index = createIndex([pointFeature(1, [110, 60])])
+    const view = await renderClusters({ map: firstMap, index })
+    expect(view.result.clusters).toEqual([])
+
+    await view.rerender({ map: nextMap, index })
+
+    expect(firstMap.listenerCount('move')).toBe(0)
+    expect(nextMap.listenerCount('move')).toBe(1)
+    expect(view.result.clusters).toHaveLength(1)
+  })
+
   describe('boundsPadding', () => {
     it('includes clusters slightly outside the viewport', async () => {
       const map = new TestMap([
@@ -264,6 +296,49 @@ describe('useClusters', () => {
 
       expect(getClusters.mock.calls.length).toBeGreaterThan(callsAfterMount)
       expect(view.result.clusters).toHaveLength(1)
+    })
+
+    it('drops the cached padded area when bounds disappear', async () => {
+      const map = new TestMap([
+        [-10, -10],
+        [10, 10],
+      ])
+      const index = createIndex([pointFeature(1, [0, 0])])
+      const view = await renderClusters({ boundsPadding: 0.5, index, map })
+      expect(view.result.clusters).toHaveLength(1)
+
+      await act(async () => {
+        map.setBounds(null)
+        map.emit('move')
+      })
+      expect(view.result.clusters).toEqual([])
+
+      await act(async () => {
+        // Back inside the previously cached padded area — must requery, not reuse the empty result
+        map.setBounds([
+          [-8, -8],
+          [8, 8],
+        ])
+        map.emit('move')
+      })
+
+      expect(view.result.clusters).toHaveLength(1)
+    })
+
+    it('requeries a new index even when the viewport stays inside the padded area', async () => {
+      const map = new TestMap([
+        [-10, -10],
+        [10, 10],
+      ])
+      const firstIndex = createIndex([pointFeature(1, [0, 0])])
+      const nextIndex = createIndex([pointFeature(2, [0, 0], 7)])
+      const view = await renderClusters({ boundsPadding: 0.5, index: firstIndex, map })
+      expect(view.result.clusters[0]?.properties).toEqual({ value: 1 })
+
+      await view.rerender({ boundsPadding: 0.5, index: nextIndex, map })
+
+      expect(view.result.supercluster).toBe(nextIndex)
+      expect(view.result.clusters[0]?.properties).toEqual({ value: 7 })
     })
 
     it('always requeries without padding, even when the viewport shrinks', async () => {

--- a/src/use-clusters.ts
+++ b/src/use-clusters.ts
@@ -1,6 +1,13 @@
 import { useCallback, useMemo, useSyncExternalStore } from 'react'
 import { isClustersShallowEqual } from './cluster-equality.js'
-import { getMapState, isMapStateEqual, type MapState } from './map-state.js'
+import {
+  containsBounds,
+  expandBounds,
+  getMapState,
+  isMapStateEqual,
+  type MapBounds,
+  type MapState,
+} from './map-state.js'
 import type { Cluster, GeoJsonProperties, MapLike, SuperclusterInstance } from './types.js'
 
 type ClustersResult<TFeatureProperties extends GeoJsonProperties, TClusterProperties extends GeoJsonProperties> = {
@@ -14,10 +21,14 @@ type ClustersResult<TFeatureProperties extends GeoJsonProperties, TClusterProper
  * The map is treated as an external store and the whole result is the snapshot:
  * `clusters` and `supercluster` stay atomic, and the result keeps its identity
  * (no re-render) while the visible clusters stay shallowly equal.
+ *
+ * With `boundsPadding > 0` clusters are queried for an expanded viewport and
+ * reused while the map keeps moving inside it at the same rounded zoom.
  */
 export function useClusters<TFeatureProperties extends GeoJsonProperties, TClusterProperties extends GeoJsonProperties>(
   map: MapLike | null,
   supercluster: SuperclusterInstance<TFeatureProperties, TClusterProperties>,
+  boundsPadding = 0,
 ): ClustersResult<TFeatureProperties, TClusterProperties> {
   const subscribe = useCallback(
     (onStoreChange: () => void) => {
@@ -31,8 +42,8 @@ export function useClusters<TFeatureProperties extends GeoJsonProperties, TClust
   )
 
   const { getSnapshot, getServerSnapshot } = useMemo(
-    () => createClustersSnapshot(map, supercluster),
-    [map, supercluster],
+    () => createClustersSnapshot(map, supercluster, boundsPadding),
+    [map, supercluster, boundsPadding],
   )
 
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
@@ -43,17 +54,31 @@ export function useClusters<TFeatureProperties extends GeoJsonProperties, TClust
 function createClustersSnapshot<
   TFeatureProperties extends GeoJsonProperties,
   TClusterProperties extends GeoJsonProperties,
->(map: MapLike | null, supercluster: SuperclusterInstance<TFeatureProperties, TClusterProperties>) {
+>(
+  map: MapLike | null,
+  supercluster: SuperclusterInstance<TFeatureProperties, TClusterProperties>,
+  boundsPadding: number,
+) {
   const emptyResult: ClustersResult<TFeatureProperties, TClusterProperties> = { clusters: [], supercluster }
+  const queriedArea = createQueriedArea(boundsPadding)
   let mapState: MapState | null = null
   let result = emptyResult
 
   const getSnapshot = (): ClustersResult<TFeatureProperties, TClusterProperties> => {
     const nextMapState = map == null ? null : getMapState(map)
     if (isMapStateEqual(mapState, nextMapState)) return result
-
     mapState = nextMapState
-    const clusters = nextMapState == null ? [] : supercluster.getClusters(nextMapState.bounds, nextMapState.zoom)
+
+    // The viewport is still inside the padded area at the same zoom — reuse the queried clusters
+    if (nextMapState != null && queriedArea.covers(nextMapState)) return result
+
+    let clusters: Array<Cluster<TFeatureProperties, TClusterProperties>>
+    if (nextMapState == null) {
+      queriedArea.reset()
+      clusters = []
+    } else {
+      clusters = supercluster.getClusters(queriedArea.update(nextMapState), nextMapState.zoom)
+    }
 
     // Clusters might stay the same while the viewport moves — keep the identity to avoid re-renders
     if (!isClustersShallowEqual(result.clusters, clusters)) {
@@ -63,6 +88,30 @@ function createClustersSnapshot<
   }
 
   return { getSnapshot, getServerSnapshot: () => emptyResult }
+}
+
+// Remembers the last queried (padded) area so movements inside it can reuse the
+// previous result instead of querying the index again.
+function createQueriedArea(boundsPadding: number) {
+  let queried: { bounds: MapBounds; zoom: number } | null = null
+
+  const covers = (mapState: MapState): boolean =>
+    boundsPadding > 0 &&
+    queried != null &&
+    queried.zoom === mapState.zoom &&
+    containsBounds(queried.bounds, mapState.bounds)
+
+  const update = (mapState: MapState): MapBounds => {
+    const bounds = boundsPadding > 0 ? expandBounds(mapState.bounds, boundsPadding) : mapState.bounds
+    queried = { bounds, zoom: mapState.zoom }
+    return bounds
+  }
+
+  const reset = (): void => {
+    queried = null
+  }
+
+  return { covers, update, reset }
 }
 
 function noop(): void {}

--- a/src/use-clusters.ts
+++ b/src/use-clusters.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useMemo, useSyncExternalStore } from 'react'
 import { isClustersShallowEqual } from './cluster-equality.js'
 import { getMapState, isMapStateEqual, type MapState } from './map-state.js'
 import type { Cluster, GeoJsonProperties, MapLike, SuperclusterInstance } from './types.js'
@@ -8,71 +8,61 @@ type ClustersResult<TFeatureProperties extends GeoJsonProperties, TClusterProper
   supercluster: SuperclusterInstance<TFeatureProperties, TClusterProperties>
 }
 
-type ClustersState<TFeatureProperties extends GeoJsonProperties, TClusterProperties extends GeoJsonProperties> = {
-  mapState: MapState | null
-  result: ClustersResult<TFeatureProperties, TClusterProperties>
-}
-
 /**
  * Subscribes to map movements and returns clusters for the current viewport.
  *
- * `clusters` and `supercluster` update atomically so consumers never see clusters
- * computed by a different index than the one returned alongside them.
+ * The map is treated as an external store and the whole result is the snapshot:
+ * `clusters` and `supercluster` stay atomic, and the result keeps its identity
+ * (no re-render) while the visible clusters stay shallowly equal.
  */
 export function useClusters<TFeatureProperties extends GeoJsonProperties, TClusterProperties extends GeoJsonProperties>(
   map: MapLike | null,
   supercluster: SuperclusterInstance<TFeatureProperties, TClusterProperties>,
 ): ClustersResult<TFeatureProperties, TClusterProperties> {
-  const [state, setState] = useState(() => nextClustersState(null, supercluster, map))
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (map == null) return noop
+      map.on('move', onStoreChange)
+      return () => {
+        map.off('move', onStoreChange)
+      }
+    },
+    [map],
+  )
 
-  useEffect(() => {
-    const update = (): void => {
-      setState((current) => nextClustersState(current, supercluster, map))
-    }
+  const { getSnapshot, getServerSnapshot } = useMemo(
+    () => createClustersSnapshot(map, supercluster),
+    [map, supercluster],
+  )
 
-    // The map state might have changed between render and subscription
-    update()
-
-    if (map == null) return
-    map.on('move', update)
-    return () => {
-      map.off('move', update)
-    }
-  }, [map, supercluster])
-
-  return state.result
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }
 
-function nextClustersState<TFeatureProperties extends GeoJsonProperties, TClusterProperties extends GeoJsonProperties>(
-  current: ClustersState<TFeatureProperties, TClusterProperties> | null,
-  supercluster: SuperclusterInstance<TFeatureProperties, TClusterProperties>,
-  map: MapLike | null,
-): ClustersState<TFeatureProperties, TClusterProperties> {
-  const mapState = map == null ? null : getMapState(map)
+// `getSnapshot` must return the same reference until the store changes, otherwise
+// `useSyncExternalStore` would re-render forever; hence the closure-level cache.
+function createClustersSnapshot<
+  TFeatureProperties extends GeoJsonProperties,
+  TClusterProperties extends GeoJsonProperties,
+>(map: MapLike | null, supercluster: SuperclusterInstance<TFeatureProperties, TClusterProperties>) {
+  const emptyResult: ClustersResult<TFeatureProperties, TClusterProperties> = { clusters: [], supercluster }
+  let mapState: MapState | null = null
+  let result = emptyResult
 
-  // Map or its bounds are unavailable, no clusters
-  if (mapState == null) {
-    if (
-      current != null &&
-      current.result.supercluster === supercluster &&
-      current.mapState == null &&
-      current.result.clusters.length === 0
-    ) {
-      return current
+  const getSnapshot = (): ClustersResult<TFeatureProperties, TClusterProperties> => {
+    const nextMapState = map == null ? null : getMapState(map)
+    if (isMapStateEqual(mapState, nextMapState)) return result
+
+    mapState = nextMapState
+    const clusters = nextMapState == null ? [] : supercluster.getClusters(nextMapState.bounds, nextMapState.zoom)
+
+    // Clusters might stay the same while the viewport moves — keep the identity to avoid re-renders
+    if (!isClustersShallowEqual(result.clusters, clusters)) {
+      result = { clusters, supercluster }
     }
-    return { mapState: null, result: { clusters: [], supercluster } }
+    return result
   }
 
-  // Supercluster has changed, always re-ask clusters
-  if (current == null || current.result.supercluster !== supercluster) {
-    return { mapState, result: { clusters: supercluster.getClusters(mapState.bounds, mapState.zoom), supercluster } }
-  }
-
-  if (isMapStateEqual(current.mapState, mapState)) return current
-
-  // Map state has changed, but visible clusters might stay the same — avoid redundant re-renders
-  const clusters = supercluster.getClusters(mapState.bounds, mapState.zoom)
-  return isClustersShallowEqual(current.result.clusters, clusters)
-    ? current
-    : { mapState, result: { clusters, supercluster } }
+  return { getSnapshot, getServerSnapshot: () => emptyResult }
 }
+
+function noop(): void {}

--- a/src/use-supercluster-index.ts
+++ b/src/use-supercluster-index.ts
@@ -1,20 +1,14 @@
 import { DEV } from 'esm-env'
 import { useMemo, useRef } from 'react'
 import Supercluster from 'supercluster'
-import type {
-  GeoJsonProperties,
-  PointFeature,
-  PointFeatureProperties,
-  SuperclusterInstance,
-  SuperclusterOptions,
-} from './types.js'
+import type { GeoJsonProperties, PointFeature, SuperclusterInstance, SuperclusterOptions } from './types.js'
 import { useWarnOnUnstableFunctionOptions } from './warn-unstable-options.js'
 
 type UseSuperclusterIndex = <
   TFeatureProperties extends GeoJsonProperties,
   TClusterProperties extends GeoJsonProperties,
 >(
-  points: Array<PointFeature<PointFeatureProperties<TFeatureProperties>>>,
+  points: Array<PointFeature<TFeatureProperties>>,
   options: SuperclusterOptions<TFeatureProperties, TClusterProperties>,
 ) => SuperclusterInstance<TFeatureProperties, TClusterProperties>
 
@@ -27,7 +21,7 @@ function useSuperclusterIndexWithWarnings<
   TFeatureProperties extends GeoJsonProperties,
   TClusterProperties extends GeoJsonProperties,
 >(
-  points: Array<PointFeature<PointFeatureProperties<TFeatureProperties>>>,
+  points: Array<PointFeature<TFeatureProperties>>,
   options: SuperclusterOptions<TFeatureProperties, TClusterProperties>,
 ) {
   useWarnOnUnstableFunctionOptions(options)
@@ -38,7 +32,7 @@ function useSuperclusterIndexImpl<
   TFeatureProperties extends GeoJsonProperties,
   TClusterProperties extends GeoJsonProperties,
 >(
-  outerPoints: Array<PointFeature<PointFeatureProperties<TFeatureProperties>>>,
+  outerPoints: Array<PointFeature<TFeatureProperties>>,
   outerOptions: SuperclusterOptions<TFeatureProperties, TClusterProperties>,
 ) {
   const nextOptions = normalizeOptions(outerOptions)

--- a/src/use-supercluster-index.ts
+++ b/src/use-supercluster-index.ts
@@ -2,6 +2,7 @@ import { DEV } from 'esm-env'
 import { useMemo, useRef } from 'react'
 import Supercluster from 'supercluster'
 import type { GeoJsonProperties, PointFeature, SuperclusterInstance, SuperclusterOptions } from './types.js'
+import { useWarnOnReservedClusterKey } from './warn-reserved-cluster-key.js'
 import { useWarnOnUnstableFunctionOptions } from './warn-unstable-options.js'
 
 type UseSuperclusterIndex = <
@@ -24,6 +25,7 @@ function useSuperclusterIndexWithWarnings<
   points: Array<PointFeature<TFeatureProperties>>,
   options: SuperclusterOptions<TFeatureProperties, TClusterProperties>,
 ) {
+  useWarnOnReservedClusterKey(points)
   useWarnOnUnstableFunctionOptions(options)
   return useSuperclusterIndexImpl(points, options)
 }

--- a/src/use-supercluster.test.ts
+++ b/src/use-supercluster.test.ts
@@ -1,4 +1,3 @@
-import type { RefObject } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { pointFeature, renderHook, type TestClusterProperties, TestMap, type TestProperties } from './test-helpers.js'
 import type { PointFeature } from './types.js'
@@ -53,24 +52,10 @@ describe('create', () => {
       expect(explicitMap.listenerCount('move')).toBe(1)
     })
 
-    it('accepts an explicit React ref', async () => {
-      const map = new TestMap([
-        [-10, -10],
-        [10, 10],
-      ])
+    it('treats an explicit null mapRef as unavailable map', async () => {
       const useSupercluster = create<TestMap>(() => ({}))
       const view = await renderUseSupercluster(useSupercluster, {
-        options: { mapRef: { current: map } as RefObject<TestMap> },
-        points: [pointFeature(1, [0, 0])],
-      })
-
-      expect(view.result.clusters).toHaveLength(1)
-    })
-
-    it('treats an empty explicit React ref as unavailable map', async () => {
-      const useSupercluster = create<TestMap>(() => ({}))
-      const view = await renderUseSupercluster(useSupercluster, {
-        options: { mapRef: { current: null } as RefObject<TestMap | null> },
+        options: { mapRef: null },
         points: [pointFeature(1, [0, 0])],
       })
 

--- a/src/use-supercluster.test.ts
+++ b/src/use-supercluster.test.ts
@@ -96,6 +96,20 @@ describe('create', () => {
     expect(view.result.clusters[0]?.properties).toMatchObject({ cluster: true, sum: 5 })
   })
 
+  it('passes boundsPadding through to clustering', async () => {
+    const map = new TestMap([
+      [-10, -10],
+      [10, 10],
+    ])
+    const useSupercluster = create(() => ({ current: map }))
+    const view = await renderUseSupercluster(useSupercluster, {
+      options: { boundsPadding: 0.5 },
+      points: [pointFeature(1, [12, 12])],
+    })
+
+    expect(view.result.clusters).toHaveLength(1)
+  })
+
   it('works under React StrictMode', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const map = new TestMap([

--- a/src/use-supercluster.ts
+++ b/src/use-supercluster.ts
@@ -41,7 +41,7 @@ export type UseSuperclusterOptions<
    *
    * @default 0
    */
-  boundsPadding?: number
+  boundsPadding?: number | undefined
 }
 
 type UseMap<T> = () => {

--- a/src/use-supercluster.ts
+++ b/src/use-supercluster.ts
@@ -33,6 +33,16 @@ export type UseSuperclusterOptions<
   TClusterProperties extends GeoJsonProperties,
 > = SuperclusterOptions<TFeatureProperties, TClusterProperties> & {
   mapRef?: MapRef | RefObject<MapRef | null | undefined> | undefined | null
+  /**
+   * Extra viewport fraction (per side) included when querying clusters.
+   *
+   * Markers near the edges don't pop in and out, and small pans inside the
+   * padded area skip recomputation entirely. The queried area grows as
+   * `(1 + 2 * padding)²`, so large values render more off-screen markers.
+   *
+   * @default 0
+   */
+  boundsPadding?: number
 }
 
 type UseMap<T> = () => {
@@ -53,7 +63,7 @@ export function create<MapRef extends MapLike>(useMap: UseMap<MapRef>) {
   ): UseSuperclusterReturnValue<TFeatureProperties, TClusterProperties> {
     const map = useResolvedMap(options.mapRef)
     const supercluster = useSuperclusterIndex(points, options)
-    return useClusters(map, supercluster)
+    return useClusters(map, supercluster, options.boundsPadding)
   }
 
   function useResolvedMap(mapRef?: MapRef | RefObject<MapRef | null | undefined> | null | undefined): MapRef | null {

--- a/src/use-supercluster.ts
+++ b/src/use-supercluster.ts
@@ -1,4 +1,3 @@
-import type { RefObject } from 'react'
 import type {
   Cluster,
   GeoJsonProperties,
@@ -32,7 +31,7 @@ export type UseSuperclusterOptions<
   TFeatureProperties extends GeoJsonProperties,
   TClusterProperties extends GeoJsonProperties,
 > = SuperclusterOptions<TFeatureProperties, TClusterProperties> & {
-  mapRef?: MapRef | RefObject<MapRef | null | undefined> | undefined | null
+  mapRef?: MapRef | undefined | null
   /**
    * Extra viewport fraction (per side) included when querying clusters.
    *
@@ -66,9 +65,8 @@ export function create<MapRef extends MapLike>(useMap: UseMap<MapRef>) {
     return useClusters(map, supercluster, options.boundsPadding)
   }
 
-  function useResolvedMap(mapRef?: MapRef | RefObject<MapRef | null | undefined> | null | undefined): MapRef | null {
+  function useResolvedMap(mapRef?: MapRef | null | undefined): MapRef | null {
     const maps = useMap()
-    if (mapRef != null) return 'current' in mapRef ? (mapRef.current ?? null) : mapRef
-    return maps.current ?? null
+    return mapRef ?? maps.current ?? null
   }
 }

--- a/src/use-supercluster.ts
+++ b/src/use-supercluster.ts
@@ -15,7 +15,7 @@ export type UseSuperclusterReturnValue<
   TFeatureProperties extends GeoJsonProperties,
   TClusterProperties extends GeoJsonProperties,
 > = {
-  /** Clusters for the current map bounds and rounded zoom. */
+  /** Clusters for the current — optionally padded — map bounds and rounded zoom. */
   clusters: Array<Cluster<TFeatureProperties, TClusterProperties>>
   /** Loaded index for advanced `supercluster` queries. */
   supercluster: SuperclusterInstance<TFeatureProperties, TClusterProperties>
@@ -35,9 +35,10 @@ export type UseSuperclusterOptions<
   /**
    * Extra viewport fraction (per side) included when querying clusters.
    *
-   * Markers near the edges don't pop in and out, and small pans inside the
-   * padded area skip recomputation entirely. The queried area grows as
-   * `(1 + 2 * padding)²`, so large values render more off-screen markers.
+   * Markers near the edges don't pop in and out, and pans inside the padded
+   * area at the same rounded zoom skip recomputation entirely. The queried
+   * area grows as `(1 + 2 * padding)²`, so large values render more
+   * off-screen markers. Non-positive values disable padding.
    *
    * @default 0
    */

--- a/src/use-supercluster.ts
+++ b/src/use-supercluster.ts
@@ -55,10 +55,10 @@ type UseMap<T> = () => {
  */
 export function create<MapRef extends MapLike>(useMap: UseMap<MapRef>) {
   return function useSupercluster<
-    TFeatureProperties extends GeoJsonProperties,
+    TFeatureProperties extends PointFeatureProperties,
     TClusterProperties extends GeoJsonProperties,
   >(
-    points: Array<PointFeature<PointFeatureProperties<TFeatureProperties>>>,
+    points: Array<PointFeature<TFeatureProperties>>,
     options: UseSuperclusterOptions<MapRef, TFeatureProperties, TClusterProperties> = {},
   ): UseSuperclusterReturnValue<TFeatureProperties, TClusterProperties> {
     const map = useResolvedMap(options.mapRef)

--- a/src/warn-reserved-cluster-key.test.ts
+++ b/src/warn-reserved-cluster-key.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { pointFeature, renderHook } from './test-helpers.js'
+import type { GeoJsonProperties, PointFeature } from './types.js'
+import { useWarnOnReservedClusterKey } from './warn-reserved-cluster-key.js'
+
+type Points = Array<PointFeature<GeoJsonProperties>>
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useWarnOnReservedClusterKey', () => {
+  it('does not warn for points without the cluster key', async () => {
+    const warn = spyOnWarn()
+    const view = await renderWarnings([pointFeature(1, [0, 0])])
+
+    await view.rerender([pointFeature(2, [1, 1])])
+
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('warns when a point defines the reserved cluster key', async () => {
+    const warn = spyOnWarn()
+
+    await renderWarnings([pointFeature(1, [0, 0]), reservedPoint()])
+
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn).toHaveBeenCalledWith(
+      'react-map-gl-supercluster: point properties must not define "cluster". ' +
+        'The key is reserved for generated clusters and makes isCluster misreport such points.',
+    )
+  })
+
+  it('warns only once across re-renders with offending points', async () => {
+    const warn = spyOnWarn()
+    const view = await renderWarnings([reservedPoint()])
+
+    await view.rerender([reservedPoint()])
+    await view.rerender([reservedPoint()])
+
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not re-scan re-renders with the same points array', async () => {
+    const warn = spyOnWarn()
+    const points: Points = [pointFeature(1, [0, 0])]
+    const view = await renderWarnings(points)
+
+    points.push(reservedPoint())
+    await view.rerender(points)
+
+    expect(warn).not.toHaveBeenCalled()
+  })
+})
+
+function renderWarnings(points: Points) {
+  return renderHook((props: Points) => useWarnOnReservedClusterKey(props), points)
+}
+
+function spyOnWarn() {
+  return vi.spyOn(console, 'warn').mockImplementation(() => {})
+}
+
+function reservedPoint(): PointFeature<GeoJsonProperties> {
+  return {
+    geometry: { coordinates: [0, 0], type: 'Point' },
+    properties: { cluster: true },
+    type: 'Feature',
+  }
+}

--- a/src/warn-reserved-cluster-key.ts
+++ b/src/warn-reserved-cluster-key.ts
@@ -1,0 +1,27 @@
+import { useRef } from 'react'
+import type { GeoJsonProperties, PointFeature } from './types.js'
+
+/**
+ * Dev-only. Warns once when input points carry the reserved `cluster` property
+ * key — the types forbid it, but it slips through widened types and makes
+ * `isCluster` misreport such points as clusters.
+ */
+export function useWarnOnReservedClusterKey(points: Array<PointFeature<GeoJsonProperties>>): void {
+  const stateRef = useRef<{ lastPoints: Array<PointFeature<GeoJsonProperties>> | null; warned: boolean }>({
+    lastPoints: null,
+    warned: false,
+  })
+
+  const state = stateRef.current
+  // Scan only new arrays, and stop scanning entirely once warned
+  if (state.warned || state.lastPoints === points) return
+
+  state.lastPoints = points
+  if (points.some((point) => 'cluster' in point.properties)) {
+    state.warned = true
+    console.warn(
+      'react-map-gl-supercluster: point properties must not define "cluster". ' +
+        'The key is reserved for generated clusters and makes isCluster misreport such points.',
+    )
+  }
+}


### PR DESCRIPTION
Replaces #6, which was auto-closed when its base branch (`v3-improvements`, #5) was deleted after merge. Same content, retargeted to `main`.

## What

- **feat!**: drive viewport clustering via `useSyncExternalStore` — the map is the external store, the whole `{clusters, supercluster}` result is the snapshot. Same-render index swaps (no double render), no stale map state, SSR-safe via `getServerSnapshot`. Peer dependency bump: `react >=18`.
- **feat**: `boundsPadding` option — clusters are queried for an expanded viewport and reused while the map keeps moving inside it at the same rounded zoom. `0` (default) preserves the exact previous behavior.
- **feat!**: accept plain point features — no more `cluster: false` in input properties. `PointFeatureProperties` became a constraint (`cluster` key is reserved), `PointClusterProperties` is removed; use `isCluster` for narrowing. A dev-only warning catches reserved-key points that slip past the types.
- **feat!**: `mapRef` accepts only a map instance (React ref objects don't notify React when filled — keep the map in state instead).
- **fix**: `Readonly` reduce argument, explicit `| undefined` on optional options for `exactOptionalPropertyTypes` consumers, `GeoJsonProperties` export.

## Breaking changes

1. `react` / `@types/react` peer `>=18.0.0`.
2. Remove `cluster: false` from point properties and drop the `PointFeatureProperties<T>` / `PointClusterProperties<T>` wrappers.
3. Pass a map instance to `mapRef` (`useState` + `<Map ref={setMap}>`), not a ref object.

## Verification

`pnpm check` green: 72 tests, 100% coverage. `pnpm build` clean incl. attw + publint. Padded-area cache lifecycle is mutation-tested.